### PR TITLE
Linux, macで動くようにファイルパスを変更

### DIFF
--- a/scraping.py
+++ b/scraping.py
@@ -3,8 +3,8 @@ from operator import itemgetter
 import datetime
 
 output = []
-
-with open('天鳳ランキング_files\dummy.html', 'r', encoding='utf-8') as f:
+path = '天鳳ランキング_files\dummy.html'
+with open(path, 'r', encoding='utf-8') as f:
     # ファイルをhtml解析しやすいよう変換
     soup = bs4.BeautifulSoup(f, 'html.parser')
 

--- a/scraping.py
+++ b/scraping.py
@@ -1,9 +1,11 @@
 import bs4
 from operator import itemgetter
 import datetime
+import os
 
 output = []
-path = '天鳳ランキング_files\dummy.html'
+path = os.path.join('天鳳ランキング_files', 'dummy.html')
+
 with open(path, 'r', encoding='utf-8') as f:
     # ファイルをhtml解析しやすいよう変換
     soup = bs4.BeautifulSoup(f, 'html.parser')


### PR DESCRIPTION
たぶんご存知だとは思いますが、Linuxやmacではファイルパスの区切り文字は `/` である一方で Windows では `\` が使われています。
複数環境下で動かすためにプログラミング言語にはそうしたファイルパスの区切り文字の違いを意識しないように済む仕組みがあることがほとんどです。
python は `os.path` が該当します。 `os.path.join` だとOSに適した区切り文字が選ばれるのでそうしました。